### PR TITLE
Increment version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # Solr Mongo Importer
 Welcome to the Solr Mongo Importer project. This project provides MongoDb support for the Solr Data Import Handler.
 
+## Differences between this fork and the upstream
+
+I'm writing this from memory as the author did not update the readme himself or provide detailed commit logs, but it should be accurate based on what I saw in the code comments and the conversation I had with him when he published the code.
+
+BuyerQuest uses Mongodb replica sets which requires that the connector perform a discovery process through the MongoDB driver. The original code did not support that functionality, and so only supported connecting to an individual server instead of using a multi-server connection URI. There were also some tests added to validate this functionality.
+
+The original README.md continues below.
+
 ## Features
 * Retrive data from a MongoDb collection
 * Authenticate using MongoDb authentication

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>net.buyerquest</groupId>
     <artifactId>SolrMongoImporter</artifactId>
     <name>MongoDB Data Importer for SOLR Data Import Handler</name>
-    <version>1.0</version>
+    <version>2.0</version>
     <url>https://github.com/BuyerQuest/SolrMongoImporter</url>
     <properties>
         <solr.version>3.6.2</solr.version>


### PR DESCRIPTION
The version number set in pom.xml was lower than the version numbers used in previous releases from the upstream repo.  Incrementing here will let me draft a sane release version of this fork.