### PR TITLE
Core properties are not substituted for mongo datasource

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>net.buyerquest</groupId>
     <artifactId>SolrMongoImporter</artifactId>
     <name>MongoDB Data Importer for SOLR Data Import Handler</name>
-    <version>1.2.1</version>
+    <version>1.2.2</version>
     <url>https://github.com/BuyerQuest/SolrMongoImporter</url>
     <properties>
         <solr.version>3.6.2</solr.version>
@@ -81,8 +81,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.3</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                     <encoding>utf-8</encoding>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Fixed issue where `solrcore.properties` or `configoverlay.json` are not interpolated by solar mongo data source config.